### PR TITLE
fix/docs: fix MD syntax for reference-style links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ body {
      title="By Max Schmitt">
 
 It works with `min-height` and `max-height` too.
+
 [all other browsers]: https://caniuse.com/#feat=viewport-units
 [iOS’s bug]: https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/
 [PostCSS]: https://github.com/postcss/postcss


### PR DESCRIPTION
## Description

- needed a newline in order for the Markdown parser to understand that
  these are link references and not plain text

- c.f. https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links
- called an "implicit link name shortcut" in https://daringfireball.net/projects/markdown/syntax#link

## Rendered Screenshots

[See Rendered Version](https://github.com/postcss/postcss-100vh-fix/blob/d1762d4a2ff7f3137ec95e49f86b2a85b502c3b1/README.md)

### Before

![PostCSS 1 before](https://user-images.githubusercontent.com/4970083/95547590-52fc1880-09d1-11eb-8190-77dc41c98ba2.png)

![PostCSS 2 before](https://user-images.githubusercontent.com/4970083/95547591-52fc1880-09d1-11eb-8cab-535f971e6c76.png)

### After

![PostCSS 1 after](https://user-images.githubusercontent.com/4970083/95547621-61e2cb00-09d1-11eb-8457-0a7098ebf0af.png)
![PostCSS 2 after](https://user-images.githubusercontent.com/4970083/95547623-61e2cb00-09d1-11eb-99c3-9f523f9b277e.png)
