### PR TITLE
fix/docs: link to official docs had no reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npm install --save-dev postcss postcss-100vh-fix
 in the project root, `"postcss"` section in `package.json`
 or `postcss` in bundle config.
 
-If you do not use PostCSS, add it according to [official docs]
+If you do not use PostCSS, add it according to [official docs][PostCSS]
 and set this plugin in settings.
 
 **Step 3:** Add the plugin to plugins list:


### PR DESCRIPTION
## Description

- use the same PostCSS reference as is used at the top of the README
  to link to the PostCSS GitHub repo

## Rendered Screenshots

See [rendered version](https://github.com/postcss/postcss-100vh-fix/blob/935d979116279de6844cd85919a9b1893216acff/README.md#usage)

### Before

"[official docs]"

![Screen Shot 2022-07-19 at 9 42 48 PM](https://user-images.githubusercontent.com/4970083/179877560-9aa04075-b98d-41ee-8516-211c107c0e7b.png)

### After

"official docs" (hyperlinked)

![Screen Shot 2022-07-19 at 9 43 18 PM](https://user-images.githubusercontent.com/4970083/179877591-c10ae27b-10d0-4d2f-9551-c091edd46cbd.png)

## References

~This won't work until #5 is merged, since that fixes the broken references~ -- #5 has been merged now, I've rebased this on top.

Different variant of one of the fixes in #2, that is more consistent with the existing references. The other portion of #2 is still relevant as it fixes some grammar/typos