### PR TITLE
Add !important flag inheriting

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ function process (decl, { AtRule, Rule }) {
   media.append(clonedRule)
 
   clonedRule.append({
+    important: decl.important,
     prop: decl.prop,
     value: '-webkit-fill-available',
     source: decl.source

--- a/index.test.js
+++ b/index.test.js
@@ -35,6 +35,15 @@ it('supports max-height', () => {
   )
 })
 
+it('inherits !important flag', () => {
+  run(
+    '.max { max-height: 100vh !important }',
+    '.max { max-height: 100vh !important }\n' +
+      '@supports (-webkit-touch-callout: none) {\n' +
+      ' .max { max-height: -webkit-fill-available !important } }'
+  )
+})
+
 it('ignores non-100vh height', () => {
   run('body { max-height: 100% }', 'body { max-height: 100% }')
 })


### PR DESCRIPTION
Closes: #3 

Added inheritance of the !important flag to make the plugin's operation more explicit. This fixes issues (#3) where styles relying on the importance hierarchy might break.